### PR TITLE
Replace Loot/Transfer/Remove buttons with conditional 'Search' button when using 'Search Mode'

### DIFF
--- a/Contents/mods/InventoryTetris/media/lua/client/InventoryTetris/ItemGrid/Model/ItemContainerGrid.lua
+++ b/Contents/mods/InventoryTetris/media/lua/client/InventoryTetris/ItemGrid/Model/ItemContainerGrid.lua
@@ -128,6 +128,26 @@ function ItemContainerGrid:isOrganized()
     return self.containerDefinition.isOrganized
 end
 
+--- Check if any grids are unsearched
+function ItemContainerGrid:areAnyUnsearched()
+    for _, grid in ipairs(self.grids) do
+        if grid:isUnsearched(self.playerNum) then 
+            return true 
+        end
+    end
+    return false
+end
+
+--- Perform search on all unsearched
+function ItemContainerGrid:searchAll()
+    local player = getSpecificPlayer(self.playerNum)
+    for _, grid in ipairs(self.grids) do
+        if grid:isUnsearched(self.playerNum) then 
+            ISTimedActionQueue.add(SearchGridAction:new(player, grid))
+        end
+    end
+end
+
 function ItemContainerGrid:doesItemFit(item, gridX, gridY, gridIndex, rotate)
     local grid = self.grids[gridIndex]
     if not grid then

--- a/Contents/mods/InventoryTetris/media/lua/client/InventoryTetris/Patches/Core/InventoryTetris_InventoryPage.lua
+++ b/Contents/mods/InventoryTetris/media/lua/client/InventoryTetris/Patches/Core/InventoryTetris_InventoryPage.lua
@@ -1,12 +1,117 @@
 Events.OnGameBoot.Add(function()
+
     local og_createChildren = ISInventoryPage.createChildren
     function ISInventoryPage:createChildren()
         og_createChildren(self)
+
+        --- Button to replace the "LOOT ALL" and ""TRANSFER ALL" buttons when container needs to be searched.
+        self.searchButton = ISButton:new(3 + self:titleBarHeight() * 2 + 1, 0, 50, self:titleBarHeight(), getText("UI_tetris_buttons_search"), self, ISInventoryPage.searchAll)
+        self.searchButton:initialise()
+        self.searchButton.borderColor.a = 0.0
+        self.searchButton.backgroundColor.a = 0.0
+        self.searchButton.backgroundColorMouseOver.a = 0.7
+        self:addChild(self.searchButton)
+        self.searchButton:setVisible(false)
 
         if self.onCharacter then
             self.dragItemRenderer = DragItemRenderer:new(self.equipmentUi, self.player);
             self.dragItemRenderer:initialise();
             self.dragItemRenderer:addToUIManager();
+
+            -- Set Search to Transfer All button's location
+            self.searchButton:setX(self.transferAll:getX())
+        else
+            -- The loot panel is created 2nd always, so we can run this here
+            --- Names are reused in SpiffUI-Inventory
+            ---- Assign the player's inventory reference
+            self.friend = getPlayerInventory(self.player)
+            ---- Provide a reference to this loot panel to the player's inventory
+            self.friend.friend = self
+            
+        end
+    end
+
+    --- Perform search through all Container Grids
+    function ISInventoryPage:searchAll()
+        for _, containerUi in ipairs(self.inventoryPane.gridContainerUis) do
+            containerUi.containerGrid:searchAll()
+        end
+    end
+
+    --- Checks if any grids need searching in the active inventory, store it in var needSearch
+    function ISInventoryPage:checkNeedSearch()
+        self.needSearch = false -- default false
+        if self.inventoryPane.gridContainerUis and SandboxVars.InventoryTetris.EnableSearch then
+            if self.onCharacter then
+                for _, containerUi in ipairs(self.inventoryPane.gridContainerUis) do
+                    -- Only check for the currently selected
+                    if containerUi.inventory == containerUi.inventoryPane.inventory then
+                        self.needSearch = containerUi.containerGrid:areAnyUnsearched()
+                        return
+                    end
+                end
+            else
+                -- Do all, return true on the first unsearched
+                for _, containerUi in ipairs(self.inventoryPane.gridContainerUis) do
+                    if containerUi.containerGrid:areAnyUnsearched() then
+                        self.needSearch = true
+                        return
+                    end
+                end
+            end
+        end
+    end
+
+    -- true if buttons should be hidden, false if shown
+    function ISInventoryPage:hideLootButtons(val)
+        -- invert
+        val = not val
+        if self.onCharacter then
+            -- set transfer
+            self.transferAll:setVisible(val)
+            if self.EDNLDropItems  then
+                self.EDNLDropItems:setVisible(val)
+            end
+        else
+            -- set loot
+            self.lootAll:setVisible(val)
+            -- Handle Remove
+            self.removeAll:setVisible((val and self:isRemoveButtonVisible()) or false)
+
+            -- Support for "Easy Drop n' Loot" too
+            if self.EDNLLootItems then
+                self.EDNLLootItems:setVisible(val)
+            end
+        end
+        -- set search buttons
+        self.searchButton:setVisible((not val and self.needSearch) or false)       
+    end
+
+    -- override to handle the buttons
+    local og_prerender = ISInventoryPage.prerender
+    function ISInventoryPage:prerender()
+        og_prerender(self)
+        --- Checks if any containers need to be searched, show/hide the respective buttons
+        ---- The Loot panel is what updates both
+        self:hideLootButtons(self.needSearch or self.friend.needSearch)
+        if self.onCharacter then
+            -- Set the Search All button to the same place as "Transfer All" (resize)
+            self.searchButton:setX(self.transferAll:getX())
+        end
+    end
+
+    local og_refreshBackpacks = ISInventoryPage.refreshBackpacks
+    function ISInventoryPage:refreshBackpacks()
+        og_refreshBackpacks(self)
+        if self.inventoryPane.tetrisWindowManager then
+            local inventoryMap = {}
+            for _, backpack in ipairs(self.backpacks) do
+                inventoryMap[backpack.inventory] = true
+            end
+            self.inventoryPane.tetrisWindowManager:closeIfNotInMap(inventoryMap)
+
+            --- Checks if active container needs to be searched on refresh, cache result
+            self:checkNeedSearch()
         end
     end
 
@@ -21,19 +126,6 @@ Events.OnGameBoot.Add(function()
             self.isCollapsed = false;
             self:clearMaxDrawHeight();
             self.collapseCounter = 0;
-        end
-    end
-
-    local og_refreshBackpacks = ISInventoryPage.refreshBackpacks
-    function ISInventoryPage:refreshBackpacks()
-        og_refreshBackpacks(self)
-        if self.inventoryPane.tetrisWindowManager then
-            local inventoryMap = {}
-            for _, backpack in ipairs(self.backpacks) do
-                inventoryMap[backpack.inventory] = true
-            end
-
-            self.inventoryPane.tetrisWindowManager:closeIfNotInMap(inventoryMap)
         end
     end
 

--- a/Contents/mods/InventoryTetris/media/lua/client/InventoryTetris/TimedActions/SearchGridAction.lua
+++ b/Contents/mods/InventoryTetris/media/lua/client/InventoryTetris/TimedActions/SearchGridAction.lua
@@ -62,7 +62,14 @@ function SearchGridAction:perform()
 		self.character:getEmitter():stopSound(self.sound)
 	end
 
-    self.grid:completeSearch(self.character:getPlayerNum())
+	local num = self.character:getPlayerNum()
+	
+    self.grid:completeSearch(num)
+
+	-- we need to update our needSearch variable when a search is completed
+	---- TODO: Possibly a better way to propagate this?
+	getPlayerInventory(num):checkNeedSearch()
+	getPlayerLoot(num):checkNeedSearch()
 
     -- needed to remove from queue / start next.
 	ISBaseTimedAction.perform(self);

--- a/Contents/mods/InventoryTetris/media/lua/shared/Translate/EN/UI_EN.txt
+++ b/Contents/mods/InventoryTetris/media/lua/shared/Translate/EN/UI_EN.txt
@@ -26,4 +26,5 @@ UI_EN = {
 	UI_tetris_options_do_equip = "Equip",
 	UI_tetris_options_do_drop = "Drop",
 
+	UI_tetris_buttons_search = "Search",
 }


### PR DESCRIPTION
Fixes users being able to use the "Loot All/Transfer All/Remove All" buttons when the selected container needs searching, buttons are replaced with a "Search" button.  "Turn On" is kept untouched where applicable, includes support for mod "Easy Drop n' Loot".

String is currently translated in English with key "UI_tetris_buttons_search"

Button is conditional, but absolute.  Meaning if any selected inventory needs searching, the vanilla Loot/Transfer/Remove buttons do not show and the "Search" button does; the "Search" button also only shows on panels where it is actually required.  Using the "Search" button will perform the action on all grids that need it in the selected inventory. 

![looters](https://github.com/Notloc/zomboid-inventory-tetris/assets/23113922/7dbdef98-e6dc-427c-b714-1a88368a9314)